### PR TITLE
Add dockerfile and description on how to use the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:onbuild
+RUN mkdir -p /go/src/app
+WORKDIR /go/src/app
+
+ENV AWS_SECRET_ACCESS_KEY aws-secret-access-key
+ENV AWS_ACCESS_KEY_ID aws-access-key-id
+ENV AWS_REGION aws-region
+
+RUN go get github.com/scottjbarr/sqsmv
+
+ENTRYPOINT ["./entrypoint.sh"]
+
+ADD entrypoint.sh .
+RUN chmod 755 entrypoint.sh
+RUN chmod +x entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Supply source and destination URL endpoints.
     sqsmv -src https://region.queue.amazonaws.com/123/queue-a -dest https://region.queue.amazonaws.com/123/queue-b
 
 
+## Docker Image
+
+You can run the application with the `docker` command:
+
+`docker run -ti -e AWS_REGION -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID --name sqsmv <IMAGE_NAME> -src (...) -dest (...)`
+
 ## Seeing is believing :)
 
 Create some SQS messages to play with using the AWS CLI.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /go/src/app
+exec sqsmv "$@"


### PR DESCRIPTION
This PR adds a Dockerfile that will enable users to run `sqsmv` simply with the command below:

`docker run -ti -e AWS_REGION -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID --name sqsmv <IMAGE_NAME> -src (...) -dest (...)`