### PR TITLE
AWS: Enable shared configuration per default

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,8 @@ func main() {
 	session := session.Must(
 		session.NewSessionWithOptions(
 			session.Options{
-				// enable automatic use of AWS_PROFILE like awscli and other tools do
+				// enable automatic use of AWS_PROFILE like awscli and other
+				// tools do.
 				SharedConfigState: session.SharedConfigEnable}))
 	client := sqs.New(session)
 

--- a/main.go
+++ b/main.go
@@ -22,21 +22,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	if os.Getenv("AWS_REGION") == "" {
-		fmt.Printf("AWS_REGION not set")
-		os.Exit(1)
-	}
-
-	region := os.Getenv("AWS_REGION")
-
 	log.Printf("source queue : %v", *src)
 	log.Printf("destination queue : %v", *dest)
 
-	config := &aws.Config{
-		Region: &region,
-	}
-
-	client := sqs.New(session.New(), config)
+	session := session.Must(
+		session.NewSessionWithOptions(
+			session.Options{
+				// enable automatic use of AWS_PROFILE like awscli and other tools do
+				SharedConfigState: session.SharedConfigEnable}))
+	client := sqs.New(session)
 
 	maxMessages := int64(10)
 	waitTime := int64(0)


### PR DESCRIPTION
Currently, sqsmv requires the `AWS_*` environment variables to be set on every
use.

This is a bit tedious in the first place and even more if one is used to
use shared profiles like with `awscli` and basically all other AWS
applications built with their SDK. I don't know why the default of the
Go SDK is to not use shared credentials per default, but probably
because they want to be super low-level.

However, for a high-level user-faced application, I would prefer a user
interface similar to `awscli`.

So, this enables the use of shared configuration instead of forcing the
user to set `AWS_SDK_LOAD_CONFIG`
(see https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#hdr-Sessions_from_Shared_Config).

As a side effect, the amount of code in this project is reduced while
the same features are still available:

```
export AWS_PROFILE=bleh
export AWS_REGION=eu-west-2
```

As a side note `session.New` was deprecated.