### PR TITLE
Stop iff we receive 0 messages *twice* in succession

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 		MessageAttributeNames: messageAttributeNames,
 	}
 
+	lastMessageCount := int(1)
 	// loop as long as there are messages on the queue
 	for {
 		resp, err := client.ReceiveMessage(rmin)
@@ -55,11 +56,13 @@ func main() {
 			panic(err)
 		}
 
-		if len(resp.Messages) == 0 {
+		if lastMessageCount == 0 && len(resp.Messages) == 0 {
+			// no messages returned twice now, the queue is probably empty
 			log.Printf("done")
 			return
 		}
 
+		lastMessageCount = len(resp.Messages);
 		log.Printf("received %v messages...", len(resp.Messages))
 
 		var wg sync.WaitGroup


### PR DESCRIPTION
Sometimes SQS ReceiveMessage can return zero messages, even when there
are many more messages available to be consumed. This is a valid response
to ReceiveMessage, even when more messages are available, because the
contract only guarantees that MaxNumberOfMessages (default 10) _or less_
will be received each time ReceiveMessage is call.

After this change, we'll only consider the work of sqsmv to be done when
we receive zero messages twice in a row. This solution isn't perfect
(yes, there may still be more messages) but it should reduce the
likelihood of sqsmv stopping prematurely.

Closes #15