### PR TITLE
Add/aws profile option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 *.test
 *.prof
 dist
+.history

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Supply source and destination URL endpoints.
 
     sqsmv -src https://region.queue.amazonaws.com/123/queue-a -dest https://region.queue.amazonaws.com/123/queue-b
 
+Optionally supply also the awscli [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) to use.
+
+    sqsmv -src https://region.queue.amazonaws.com/123/queue-a -dest https://region.queue.amazonaws.com/123/queue-b -aws-profile myprofile
 
 ## Seeing is believing :)
 

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 func main() {
 	src := flag.String("src", "", "source queue")
 	dest := flag.String("dest", "", "destination queue")
+	awsProfile := flag.String("awsProfile", "", "AWS profile")
 	flag.Parse()
 
 	if *src == "" || *dest == "" {
@@ -23,10 +24,16 @@ func main() {
 
 	log.Printf("source queue : %v", *src)
 	log.Printf("destination queue : %v", *dest)
+	log.Printf("AWS profile : %v", *awsProfile)
 
 	// enable automatic use of AWS_PROFILE like awscli and other tools do.
 	opts := session.Options{
 		SharedConfigState: session.SharedConfigEnable,
+	}
+
+	// enable AWS_PROFILE selected by name (useful if you configured multiple profiles in awscli)
+	if *awsProfile != "" {
+		opts.Profile = *awsProfile
 	}
 
 	session, err := session.NewSessionWithOptions(opts)

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	src := flag.String("src", "", "source queue")
 	dest := flag.String("dest", "", "destination queue")
-	awsProfile := flag.String("awsProfile", "", "AWS profile")
+	awsProfile := flag.String("aws-profile", "", "AWS profile")
 	flag.Parse()
 
 	if *src == "" || *dest == "" {
@@ -22,9 +22,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Printf("source queue : %v", *src)
-	log.Printf("destination queue : %v", *dest)
-	log.Printf("AWS profile : %v", *awsProfile)
+	log.Printf("source queue: %v", *src)
+	log.Printf("destination queue: %v", *dest)
+	log.Printf("AWS profile: %v", *awsProfile)
 
 	// enable automatic use of AWS_PROFILE like awscli and other tools do.
 	opts := session.Options{


### PR DESCRIPTION
Hello, I added a cli argument to let users to pass the name of the awscli configured profile to use when running the command.
I think it is very useful especially on machines, like mine, where there are multiple aws configs configured.

Please let me know if in some way the style of the update doesn't match your own style, and feel free to update it yourself. I'm very new to go language 😄

Thanks,
Simone