### PR TITLE
feat: multi-region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,23 @@
 # sqsmv
 
-Move all messages from one SQS queue, to another.
-
+Move all messages from one SQS queue to another.
 
 ## Installation
 
 ### Source
 
-    go get github.com/scottjbarr/sqsmv
-
-
-### Binaries
-
-Download the appropriate binary from the
-[Releases](https://github.com/scottjbarr/sqsmv/releases) page.
-
+    go get github.com/vercel/sqsmv
 
 ## Configuration
 
-The `AWS_SECRET_ACCESS_KEY`, `AWS_ACCESS_KEY_ID`, and ,`AWS_REGION`
+The `AWS_SECRET_ACCESS_KEY`, `AWS_ACCESS_KEY_ID`, and `AWS_REGION`
 environment variables must be set.
-
 
 ## Usage
 
 Supply source and destination URL endpoints.
 
     sqsmv -src https://region.queue.amazonaws.com/123/queue-a -dest https://region.queue.amazonaws.com/123/queue-b
-
-
-## Seeing is believing :)
-
-Create some SQS messages to play with using the AWS CLI.
-
-    for i in {0..24..1}; do
-        aws sqs send-message \
-            --queue-url https://ap-southeast-2.queue.amazonaws.com/123/wat-a
-            --message-body "{\"id\": $i}"
-    done
-
 
 ## License
 


### PR DESCRIPTION
This pull request extends `sqsmv` to support moving messages across regions. This is accomplished via a naive regex match, relying on the region to be the first value in the URL (which is currently true for all SQS URL formats).