### PR TITLE
Support a -clients CLI parameter and the use of parallelizer to run jobs in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Supply source and destination URL endpoints.
 
     sqsmv -src https://region.queue.amazonaws.com/123/queue-a -dest https://region.queue.amazonaws.com/123/queue-b
 
-To run jobs in parallel, use -numClients parameter:
+To run jobs in parallel, use -clients parameter:
 
-    sqsmv -src https://region.queue.amazonaws.com/123/queue-a -dest https://region.queue.amazonaws.com/123/queue-b -numClients 8
+    sqsmv -src https://region.queue.amazonaws.com/123/queue-a -dest https://region.queue.amazonaws.com/123/queue-b -clients 8
 
 ## Seeing is believing :)
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Supply source and destination URL endpoints.
 
     sqsmv -src https://region.queue.amazonaws.com/123/queue-a -dest https://region.queue.amazonaws.com/123/queue-b
 
+To run jobs in parallel, use -numClients parameter:
+
+    sqsmv -src https://region.queue.amazonaws.com/123/queue-a -dest https://region.queue.amazonaws.com/123/queue-b -numClients 8
 
 ## Seeing is believing :)
 

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 }
 
 //transferMessages loops, transferring a number of messages from the src to the dest at an interval.
-func transferMessages(theSession *session.Session, rMin *sqs.ReceiveMessageInput, dest *string, wgOuter *sync.WaitGroup) {
+func transferMessages(theSession *session.Session, rmin *sqs.ReceiveMessageInput, dest *string, wgOuter *sync.WaitGroup) {
 	client := sqs.New(theSession)
 
 	lastMessageCount := int(1)
@@ -68,7 +68,7 @@ func transferMessages(theSession *session.Session, rMin *sqs.ReceiveMessageInput
 
 	// loop as long as there are messages on the queue
 	for {
-		resp, err := client.ReceiveMessage(rMin)
+		resp, err := client.ReceiveMessage(rmin)
 
 		if err != nil {
 			panic(err)
@@ -106,7 +106,7 @@ func transferMessages(theSession *session.Session, rMin *sqs.ReceiveMessageInput
 
 				// message was sent, dequeue from source queue
 				dmi := &sqs.DeleteMessageInput{
-					QueueUrl:      rMin.QueueUrl,
+					QueueUrl:      rmin.QueueUrl,
 					ReceiptHandle: m.ReceiptHandle,
 				}
 

--- a/main.go
+++ b/main.go
@@ -9,48 +9,73 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
+
+	"github.com/shomali11/parallelizer"
 )
 
 func main() {
 	src := flag.String("src", "", "source queue")
 	dest := flag.String("dest", "", "destination queue")
+	numClients := flag.Int("numClients", 1, "number of clients")
 	flag.Parse()
 
-	if *src == "" || *dest == "" {
+	if *src == "" || *dest == "" || *numClients < 1 {
 		flag.Usage()
 		os.Exit(1)
 	}
 
 	log.Printf("source queue : %v", *src)
 	log.Printf("destination queue : %v", *dest)
+	log.Printf("number of clients : %v", *numClients)
 
 	// enable automatic use of AWS_PROFILE like awscli and other tools do.
 	opts := session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}
 
-	session, err := session.NewSessionWithOptions(opts)
+	newSession, err := session.NewSessionWithOptions(opts)
 	if err != nil {
 		panic(err)
 	}
-
-	client := sqs.New(session)
 
 	maxMessages := int64(10)
 	waitTime := int64(0)
 	messageAttributeNames := aws.StringSlice([]string{"All"})
 
-	rmin := &sqs.ReceiveMessageInput{
+	rMin := &sqs.ReceiveMessageInput{
 		QueueUrl:              src,
 		MaxNumberOfMessages:   &maxMessages,
 		WaitTimeSeconds:       &waitTime,
 		MessageAttributeNames: messageAttributeNames,
 	}
 
+	if *numClients > 1 {
+		group := parallelizer.NewGroup(parallelizer.WithPoolSize(*numClients))
+		defer group.Close()
+		for i := 1; i <= *numClients; i++ {
+			group.Add(func() {
+				transferMessages(newSession, rMin, dest)
+			})
+		}
+		err = group.Wait()
+	} else {
+		transferMessages(newSession, rMin, dest)
+	}
+
+	log.Println("all done")
+	if err != nil {
+		log.Printf("error: %v", err)
+	}
+}
+
+//transferMessages loops, transferring a number of messages from the src to the dest at an interval.
+func transferMessages(theSession *session.Session, rMin *sqs.ReceiveMessageInput, dest *string) {
+	client := sqs.New(theSession)
+
 	lastMessageCount := int(1)
 	// loop as long as there are messages on the queue
 	for {
-		resp, err := client.ReceiveMessage(rmin)
+		resp, err := client.ReceiveMessage(rMin)
 
 		if err != nil {
 			panic(err)
@@ -88,7 +113,7 @@ func main() {
 
 				// message was sent, dequeue from source queue
 				dmi := &sqs.DeleteMessageInput{
-					QueueUrl:      src,
+					QueueUrl:      rMin.QueueUrl,
 					ReceiptHandle: m.ReceiptHandle,
 				}
 


### PR DESCRIPTION
This helps when using the following CLI invocation, to use one credential provisioning from `aws-vault` to enable multiple jobs easily:

    aws-vault exec escalated-role -- sqsmv -src "https://sqs.us-east-1.amazonaws.com/src_queue" -dest "https://sqs.us-east-1.amazonaws.com/dest_queue" -clients 8

